### PR TITLE
feat(game): paddle density 변경

### DIFF
--- a/frontend/src/matterEngine/matterJsUnit.ts
+++ b/frontend/src/matterEngine/matterJsUnit.ts
@@ -19,6 +19,7 @@ export const paddle = (x: number, y: number, width: number, height: number, labe
   return Bodies.rectangle(x, y, width, height, {
     label,
     isStatic: false,
+    density: 2,
     render: {
       sprite : {
         texture : label == 'PaddleLeft' ? '/assets/flat-fish-left.png' : '/assets/flat-fish-right.png',


### PR DESCRIPTION

![image](https://github.com/pong-nyan/pong-nyan/assets/60354633/dd439704-0827-4235-a0a1-a9c387fa8213)


밀도와 질량은 비례관계이고,
밀도와 부피는 반비례관계이기 때문에

부피가 일정한 상태에서는
밀도가 2배 되면, 질량이 2배가 되어서

최종적으로는 질량을 2배한 효과를 볼 수 있음

=> 이제 더이상 페달이 밀리지 않음