### PR TITLE
80 게임 엔티디 생성 및 엔티디 업데이트 로직 구현

### DIFF
--- a/backend/src/config/datasource.ts
+++ b/backend/src/config/datasource.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { User } from '../entity/User';
+import { User } from 'src/entity/User';
+import { Game } from 'src/entity/Game';
 
 @Module({
   imports: [
@@ -13,7 +14,7 @@ import { User } from '../entity/User';
       database: process.env.POSTGRES_DB,
       synchronize: true,
       logging: true,
-      entities: [User],
+      entities: [ User, Game ],
     }),
   ],
 })

--- a/backend/src/entity/Game.ts
+++ b/backend/src/entity/Game.ts
@@ -1,0 +1,23 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id : number;
+
+    @Column()
+    winner: string;
+
+    @Column()
+    loser: string;
+
+    // Game mode, 0: normal, 1: ranked
+    @Column()
+    gameMode: number;
+
+    @Column()
+    rankScore: number;
+
+    @Column({ type: 'jsonb' })
+    gameInfo: JSON;
+}

--- a/backend/src/entity/Game.ts
+++ b/backend/src/entity/Game.ts
@@ -5,11 +5,13 @@ export class User {
     @PrimaryGeneratedColumn()
     id : number;
 
+    // 42 intra id
     @Column()
-    winner: string;
+    winner: number;
 
+    // 42 intra id
     @Column()
-    loser: string;
+    loser: number;
 
     // Game mode, 0: normal, 1: ranked
     @Column()

--- a/backend/src/entity/Game.ts
+++ b/backend/src/entity/Game.ts
@@ -1,7 +1,7 @@
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
-export class User {
+export class Game {
     @PrimaryGeneratedColumn()
     id : number;
 

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { GameService } from './game.service';
 import { GameGateway } from './game.gateway';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Game } from 'src/entity/Game';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([ Game ])],
   providers: [GameService, GameGateway],
 })
 export class GameModule {}

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -1,4 +1,7 @@
 import { Injectable } from '@nestjs/common';
+import { Game } from 'src/entity/Game';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { Socket } from 'socket.io';
 import { BallInfo, GameInfo, RoomName } from 'src/type/game';
 
@@ -11,7 +14,7 @@ export class GameService {
     recentBallInfoMap = new Map<RoomName, BallInfo>();
     gameMap = new Map<RoomName, GameInfo>();
 
-
+    constructor(@InjectRepository(Game) private readonly gameRepository: Repository) { }
     match(client: Socket) {
         this.matchingQueue.push(client);
 
@@ -65,6 +68,15 @@ export class GameService {
     removeMatchingClient(client: Socket) {
         this.matchingQueue = this.matchingQueue.filter(item => item !== client);
         console.log(this.matchingQueue.length);
+    }
+
+    async addGameInfo(winner: number, loser: number, gameMode: number, rankScore: number, gameInfo: JSON) {
+        await this.historyRepository.insert({ winner, loser, gameMode, rankScore, gameInfo });
+    }
+
+    async getMyGameInfo(intraId: number) {
+        if (!intraId) return null;
+        return await this.historyRepository.find({ where: [{ winner: intraId }, { loser: intraId }] });
     }
 }
 

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -14,7 +14,7 @@ export class GameService {
     recentBallInfoMap = new Map<RoomName, BallInfo>();
     gameMap = new Map<RoomName, GameInfo>();
 
-    constructor(@InjectRepository(Game) private readonly gameRepository: Repository) { }
+    constructor(@InjectRepository(Game) private readonly gameRepository: Repository<Game>) { }
     match(client: Socket) {
         this.matchingQueue.push(client);
 
@@ -71,12 +71,12 @@ export class GameService {
     }
 
     async addGameInfo(winner: number, loser: number, gameMode: number, rankScore: number, gameInfo: JSON) {
-        await this.historyRepository.insert({ winner, loser, gameMode, rankScore, gameInfo });
+        await this.gameRepository.insert({ winner, loser, gameMode, rankScore, gameInfo });
     }
 
     async getMyGameInfo(intraId: number) {
         if (!intraId) return null;
-        return await this.historyRepository.find({ where: [{ winner: intraId }, { loser: intraId }] });
+        return await this.gameRepository.find({ where: [{ winner: intraId }, { loser: intraId }] });
     }
 }
 

--- a/frontend/src/components/game/logic/resumeGame.ts
+++ b/frontend/src/components/game/logic/resumeGame.ts
@@ -1,9 +1,10 @@
 import { setStartBall } from '@/matterEngine/matterJsSet';
 import { Engine, Body } from 'matter-js';
 import { findTarget } from '@/matterEngine/matterJsUnit';
-const resumeGame = (engine: Engine) => {
+import { PlayerNumber } from '@/type';
+const resumeGame = (engine: Engine, loser: PlayerNumber) => {
   // 미리 공을 세팅해놓고 3초 뒤에 공을 움직이게 함. 순서 바꾸면 벽이 뚫리는 버그 발생
-  setStartBall(engine.world);
+  setStartBall(engine.world, loser);
   setTimeout(() => {
     Body.setStatic(findTarget(engine.world, 'Ball'), false);
   }, 3000);

--- a/frontend/src/context/socketGameEvent.ts
+++ b/frontend/src/context/socketGameEvent.ts
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from 'react';
 import { socket } from '@/context/socket';
 import { KeyEventMessage, PlayerNumber } from '@/type';
-import { Body, Engine, Runner } from 'matter-js';
+import { Body, Engine } from 'matter-js';
 import { findTarget } from '@/matterEngine/matterJsUnit';
 import { movePlayer, movePaddle } from '@/matterEngine/player';
 import { resumeGame } from '@/components/game/logic/resumeGame';
@@ -103,7 +103,7 @@ export const socketOnGameScoreEvent = (engine: Engine | undefined, setScore: Dis
       else if (loser === 'player2') { return { p1: prevScore.p1 + 1, p2: prevScore.p2}; }
       else { return prevScore; }
     });
-    resumeGame(engine);
+    resumeGame(engine, loser);
   });
 };
 


### PR DESCRIPTION
# SUMMARY
1. game 엔티디 생성
2. 게임 서비스 간단 구현

# TEST
![image](https://github.com/pong-nyan/pong-nyan/assets/62806979/6cc46686-7767-4a7d-bee8-f8ccb4fa16dd)
- 게임 엔티디 생성 확인함.  (로컬에서 안 보일 시 볼륨 날리고 재실행)
- 게임 엔티디관련 함수들은 동작 확인 못 함.


# 제안
게임이 끝나면 `addGameInfo()` 호출 &&  `user의 RankScore` 업데이트 필요.  둘을 하나의 트랜잭션으로 묶으면 더 좋을 듯.

---



# BRAKING CHANGE 
기존에는 history 라는 이름이였지만, game이 더 직관적인거 같아. game으로 수정. 다른 의견이 있다면 comment  부탁드립니다.

![image](https://github.com/pong-nyan/pong-nyan/assets/62806979/032420b8-d965-4baf-a664-f0053414f999)

# INFO
see: JSON vs JSONB
게임정보는 JSONB으로 저장.
 https://americanopeople.tistory.com/300