### PR TITLE
feat(backend): GameGuard, PnJwtPayload 완성

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,6 +21,7 @@
         "axios": "^1.4.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "cookie": "^0.5.0",
         "cookie-parser": "^1.4.6",
         "otplib": "^12.0.1",
         "pg": "^8.11.2",
@@ -3462,9 +3463,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3479,6 +3480,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
@@ -3811,6 +3820,14 @@
       "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -4222,14 +4239,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "axios": "^1.4.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "cookie": "^0.5.0",
     "cookie-parser": "^1.4.6",
     "otplib": "^12.0.1",
     "pg": "^8.11.2",

--- a/backend/src/game/game.dto.ts
+++ b/backend/src/game/game.dto.ts
@@ -1,0 +1,32 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { IsNumber, IsNotEmpty, IsString } from 'class-validator';
+export class PnPayloadDto {
+    @IsNotEmpty()
+    @IsString()
+    intraId: string;
+    @IsNotEmpty()
+    @IsString()
+    nickname: string;
+    @IsNotEmpty()
+    @IsString()
+    intraNickname: string;
+    @IsNotEmpty()
+    @IsNumber()
+    iat: number;
+    @IsNotEmpty()
+    @IsNumber()
+    exp: number;
+}
+export class JwtDto {
+    @IsNotEmpty()
+    payload: PnPayloadDto;
+}
+/**
+ * CookieValue Custom Decorator
+ * description: 앞단에 UseGuards(GameGuard)가 필요함. jwt payload를 가져옴 (jwt payload는 client.user에 저장되어 있음).
+ */
+export const PnJwtPayload = createParamDecorator(async (data: unknown, ctx: ExecutionContext) => {
+    const client = ctx.switchToWs().getClient();
+    const payload = client.user;
+    return payload;
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "pong-nyan",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## SUMMARY
GameGuard, PnJwtPayload 구현 완료 

## CORE LOGIC
### GameGuard
- pn-jwt 가 있는지 검사
- pn-jwt 가 validate 한지 검사
- pn-jwt 에서 payload 를 받아서 client.user 에 넣어줌
- GameGateway Websocket  전체에 적용되도록 함

### PnJwtPayload
- pipes 커스텀 데코레이터
- GameGuard 가 적용된 범위 내에서만 사용 가능 (사용을 차단하지는 못했음)
- GameGuard 가 client.user 에 넣어준 값을 payload 로 리턴해줌

## HAVE TO KNOW
GameGuard 와 PnJwtPayload 의 사용법을 익히면 소켓의 유저검증 이벤트를 쉽게 처리할 수 있게 됩니다
Guard 에 막히면 socket event 에 error event 가 생기니 개발자도구의 소켓에서 확인할 수 있슴