### PR TITLE
115 랭킹페이지 완성

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,9 +9,10 @@ import { ChatModule } from './chat/chat.module';
 import { AppGateway } from './app.gateway';
 import { ChannelModule } from './channel/channel.module';
 import { UserService } from './user.service';
+import { RankModule } from './rank/rank.module';
 
 @Module({
-  imports: [ConfigModule.forRoot(), GameModule, AuthModule, DatabaseModule, ChatModule, ChannelModule],
+  imports: [ConfigModule.forRoot(), GameModule, AuthModule, DatabaseModule, ChatModule, ChannelModule, RankModule],
   controllers: [AppController],
   providers: [AppService, AppGateway, UserService],
 })

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -24,10 +24,10 @@ async function bootstrap() {
   app.use(json({ limit: '50mb' }));
   app.use(urlencoded({ limit: '50mb', extended: true }));
   app.useGlobalPipes(new ValidationPipe());
-  setupSwagger(app);
   app.use(server);
 
   app.setGlobalPrefix('api');
+  setupSwagger(app);
   await app.listen(4242);
 
   console.log(`🚀 Server ready at: ${ await app.getUrl()}`);

--- a/backend/src/rank/rank.controller.ts
+++ b/backend/src/rank/rank.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Param, Query, Res, Req, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { RankService } from './rank.service';
+import { RankUserDto, RankUserListDto } from './rank.dto';
+
+@Controller('rank')
+@ApiTags('rank')
+export class RankController {
+    constructor(private readonly rankService: RankService) { }
+
+    @Get()
+    @ApiOperation({ summary: 'get all rank', description: 'page에 설정한 모든 랭킹을 가져온다.' })
+    @ApiResponse({ status: HttpStatus.OK, type: RankUserListDto, description: 'page에 모든 랭킹을 가져온다. page당 10개의 데이터' })
+    @ApiParam({ name: 'page', description: 'page number, defalut = 1', required: false })
+    async getRank(@Query('page') page = 1) {
+        const result = await this.rankService.getRankInPage(page);
+        return result;
+    }
+}

--- a/backend/src/rank/rank.dto.ts
+++ b/backend/src/rank/rank.dto.ts
@@ -1,0 +1,22 @@
+import { IsNumber, IsNotEmpty, IsString } from 'class-validator';
+
+export class RankUserDto {
+    @IsNotEmpty()
+    @IsString()
+    nickname: string;
+    @IsNotEmpty()
+    @IsNumber()
+    rankScore: number;
+    @IsNotEmpty()
+    @IsNumber()
+    rank: number;
+}
+
+export class RankUserListDto {
+    data: RankUserDto[];
+    meta: {
+        total: number;
+        page: number;
+        lastPage: number;
+    };
+}

--- a/backend/src/rank/rank.module.ts
+++ b/backend/src/rank/rank.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { RankController } from './rank.controller';
+import { RankService } from './rank.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from 'src/entity/User';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ User ])],
+  controllers: [RankController],
+  providers: [RankService]
+})
+export class RankModule {}

--- a/backend/src/rank/rank.service.ts
+++ b/backend/src/rank/rank.service.ts
@@ -15,7 +15,7 @@ export class RankService {
             take: 10
         });
         return {
-            data: rankUser,
+            rankUsers: rankUser,
             meta: {
                 total,
                 page,

--- a/backend/src/rank/rank.service.ts
+++ b/backend/src/rank/rank.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from '../entity/User';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class RankService {
+    constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) { }
+
+    async getRankInPage(page: number) {
+        const [rankUser, total] = await this.userRepository.findAndCount({
+            select: ['intraNickname', 'rankScore'],
+            order: { rankScore: 'DESC' },
+            skip: (page - 1) * 10,
+            take: 10
+        });
+        return {
+            data: rankUser,
+            meta: {
+                total,
+                page,
+                lastPage: Math.ceil(total / 10)
+            }
+        };
+    }
+}

--- a/frontend/src/context/useGetFetchData.ts
+++ b/frontend/src/context/useGetFetchData.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export const useGetFetchData = (url: string | null) => {
+export const useGetFetchDataRedirect = (url: string | null) => {
   const getFetchData = async () => {
     if (url) {
       try {

--- a/frontend/src/pages/auth/callback.tsx
+++ b/frontend/src/pages/auth/callback.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import useRedirect from '../../context/useRedirect';
 import { useEffect, useState } from 'react';
-import { useGetFetchDataRedirect } from '../../context/useGetFetchData';
+import { useGetFetchDataRedirect } from '@/context/useGetFetchData';
 
 const LoginCallback = () => {
   const router = useRouter();

--- a/frontend/src/pages/auth/callback.tsx
+++ b/frontend/src/pages/auth/callback.tsx
@@ -1,14 +1,14 @@
 import { useRouter } from 'next/router';
 import useRedirect from '../../context/useRedirect';
 import { useEffect, useState } from 'react';
-import { useGetFetchData } from '../../context/useGetFetchData';
+import { useGetFetchDataRedirect } from '../../context/useGetFetchData';
 
 const LoginCallback = () => {
   const router = useRouter();
   const code = router.query.code;
   const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
   const url =  code ? `${process.env.NEXT_PUBLIC_API_URL}/auth/token?code=${code}`: null;
-  const getFetchData = useGetFetchData(url);
+  const getFetchData = useGetFetchDataRedirect(url);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/frontend/src/pages/auth/signin.tsx
+++ b/frontend/src/pages/auth/signin.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 import useNotAuth from '@/context/useNotAuth';
-import { useGetFetchData } from '@/context/useGetFetchData';
+import { useGetFetchDataRedirect } from '@/context/useGetFetchData';
 import useRedirect from '@/context/useRedirect';
 
 const SignIn = () => {
   const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
   useNotAuth();
   const url = `${process.env.NEXT_PUBLIC_API_URL}/auth/signin`;
-  const getFetchData = useGetFetchData(url);
+  const getFetchData = useGetFetchDataRedirect(url);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/frontend/src/pages/rank/index.tsx
+++ b/frontend/src/pages/rank/index.tsx
@@ -6,11 +6,9 @@ import axios from 'axios';
 const RankPage = () => {
   const [rankUsers, setRankUsers] = useState<RankUserType[]>([]);
 
-  // dummy data
   useEffect(() => {
     axios.get(`${process.env.NEXT_PUBLIC_API_URL}/rank`, { withCredentials: true })
       .then(response => {
-        console.log(response.data.rankUsers);
         setRankUsers(response.data.rankUsers);
       })
       .catch(error => {

--- a/frontend/src/pages/rank/index.tsx
+++ b/frontend/src/pages/rank/index.tsx
@@ -1,30 +1,21 @@
 import RankUserList from '@/rank/components/RankUserList';
 import { useState, useEffect } from 'react';
 import { RankUserType } from '@/rank/rankType';
+import axios from 'axios';
 
 const RankPage = () => {
   const [rankUsers, setRankUsers] = useState<RankUserType[]>([]);
 
   // dummy data
-
   useEffect(() => {
-    setRankUsers([
-      {
-        nickname: 'test1',
-        rankScore: 100,
-        rank: 1
-      },
-      {
-        nickname: 'test2',
-        rankScore: 200,
-        rank: 2
-      },
-      {
-        nickname: 'test3',
-        rankScore: 300,
-        rank: 3
-      },
-    ]);
+    axios.get(`${process.env.NEXT_PUBLIC_API_URL}/rank`, { withCredentials: true })
+      .then(response => {
+        console.log(response.data.rankUsers);
+        setRankUsers(response.data.rankUsers);
+      })
+      .catch(error => {
+        console.log(error);
+      });
   }, []);
 
   return (

--- a/frontend/src/rank/components/RankUser.tsx
+++ b/frontend/src/rank/components/RankUser.tsx
@@ -6,7 +6,7 @@ const RankUser = ({ rankUser }: RankUserProps) => {
     <div className={styles.rankUser}>
       <p>{rankUser.rank}</p>
       <p>{rankUser.rankScore}</p>
-      <p>{rankUser.nickname}</p>
+      <p>{rankUser.intraNickname}</p>
     </div>
   );
 };

--- a/frontend/src/rank/components/RankUser.tsx
+++ b/frontend/src/rank/components/RankUser.tsx
@@ -1,10 +1,10 @@
 import { RankUserProps } from '../rankType';
 import styles from '@/rank/styles/Rank.module.css';
 
-const RankUser = ({ rankUser }: RankUserProps) => {
+const RankUser = ({ rankUser, rank }: RankUserProps) => {
   return (
     <div className={styles.rankUser}>
-      <p>{rankUser.rank}</p>
+      <p>{rank}</p>
       <p>{rankUser.rankScore}</p>
       <p>{rankUser.intraNickname}</p>
     </div>

--- a/frontend/src/rank/components/RankUserList.tsx
+++ b/frontend/src/rank/components/RankUserList.tsx
@@ -6,8 +6,8 @@ const RankUserList = ({ rankUserList } : RankUserListProps) => {
   return (
     <div className={styles.rankUserList}>
       <RankUserColumn />
-      {rankUserList.map((rankUser) => (
-        <RankUser key={rankUser.intraNickname} rankUser={rankUser} />
+      {rankUserList.map((rankUser, index) => (
+        <RankUser key={rankUser.intraNickname} rankUser={rankUser} rank={index + 1} />
       ))}
     </div>
   );

--- a/frontend/src/rank/components/RankUserList.tsx
+++ b/frontend/src/rank/components/RankUserList.tsx
@@ -7,7 +7,7 @@ const RankUserList = ({ rankUserList } : RankUserListProps) => {
     <div className={styles.rankUserList}>
       <RankUserColumn />
       {rankUserList.map((rankUser) => (
-        <RankUser key={rankUser.nickname} rankUser={rankUser} />
+        <RankUser key={rankUser.intraNickname} rankUser={rankUser} />
       ))}
     </div>
   );

--- a/frontend/src/rank/rankType.ts
+++ b/frontend/src/rank/rankType.ts
@@ -1,5 +1,5 @@
 export type RankUserType = {
-    nickname: string;
+    intraNickname: string;
     rankScore: number;
     rank: number;
 };

--- a/frontend/src/rank/rankType.ts
+++ b/frontend/src/rank/rankType.ts
@@ -10,4 +10,5 @@ export type RankUserListProps = {
  
 export type RankUserProps = {
     rankUser: RankUserType;
+    rank: number;
 };


### PR DESCRIPTION
# SUMMARY
백과 랭킹페이지 연결함

# PREVIEW
![image](https://github.com/pong-nyan/pong-nyan/assets/62806979/b0491a30-02c7-44e3-98a5-2609a576c2d2)

# CORE LOGIC
frontend: c8eb9b7400c4edc14d4343a560187c56ae08aadc
backend: 614d10c60738c212a0b3bb759f5450ac237eb4b7

# BREAKING CHANGE
main.ts에서 미들웨어 순서 바꿈:  2f8c986274d26c5f238f1871a373b0a3f13b6833
useGetFetchData의 이름 바꿈: 2e6173c9465b02b6c68a258f7e80a1c4d20ca0fa 
 (사유: 리다이렉트용으로만 쓰이는 함수이기 때문)

# HAVE TO KNOW
 랭크를 따로 저장하고 있지 않기 때문에 rankScore순으로 정렬만 해서 백에서 반환함.  -> 프론트에서 index를 이용해서 rank판단함.

 백에서 rank를 바로 알고 싶다면 view를 만들거나, rank를 rankScore에 따라 자동으로 업데이트 되도록 설정해줘야함. 현재 상황에서 구현비용이 많이 들거라 생각하여 일단 보류
 
 프론트상에서만 페이지네이션은 구현되어 있지 않음.(백엔드 페이지네이션은 구현됨) -> 현재는 랭킹이 최대 10까지 밖에 안 보여줌.
 
 


