### PR TITLE
122 게임을 다양한 옵션으로 선택할 수 있도록 프론트 화면 구성

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -36,13 +36,13 @@ export class GameGateway {
     this.gameService.removeMatchingClient(client);
   }
 
-  @SubscribeMessage('game-randomStart')
+  @SubscribeMessage('game-randomStart-rank-pn')
   handleStartGame(@MessageBody() data: any, @ConnectedSocket() client: Socket, @PnJwtPayload() payload: PnPayloadDto) {
     const nickname = payload.intraNickname;
     const [ roomName, player1Id, player2Id ] = this.gameService.match(client, nickname);
     if (!roomName) this.server.to(client.id).emit('game-loading');
     if (!player1Id || !player2Id) return;
-    this.server.to(roomName).emit('game-randomStart', {player1Id, player2Id});
+    this.server.to(roomName).emit('game-randomStart-rank-pn', {player1Id, player2Id});
   }
 
   @SubscribeMessage('game-keyEvent')

--- a/frontend/src/_components/CatButton.tsx
+++ b/frontend/src/_components/CatButton.tsx
@@ -2,20 +2,23 @@ import Image from 'next/image';
 
 type CatButtonProps = {
     onClickFunction: () => void;
+    label: string;
     width: number;
     height: number;
 };
 
-const CatButton = ({ onClickFunction, width, height }: CatButtonProps) => {
+const CatButton = ({ onClickFunction, label, width, height }: CatButtonProps) => {
   return (
     <button>
       <Image src="/assets/cat-footprint.png" alt="catFootprint" onClick={onClickFunction} width={width ?? 42} height={height ?? 42} />
+      {label}
     </button>
   );
 };
 
 CatButton.defaultProps = {
   onClickFunction: () => { console.error('onClickFunction is not defined');},
+  label: 'button',
   width: 42,
   height: 42,
 };

--- a/frontend/src/_components/CatButton.tsx
+++ b/frontend/src/_components/CatButton.tsx
@@ -2,24 +2,26 @@ import Image from 'next/image';
 
 type CatButtonProps = {
     onClickFunction: () => void;
-    label: string;
+    text: string;
     width: number;
     height: number;
 };
 
-const CatButton = ({ onClickFunction, label, width, height }: CatButtonProps) => {
+const CatButton = ({ onClickFunction, text, width, height }: CatButtonProps) => {
   return (
     <button>
       <Image src="/assets/cat-footprint.png" alt="catFootprint" onClick={onClickFunction} width={width ?? 42} height={height ?? 42} />
-      {label}
+      <p>
+        {text}
+      </p>
     </button>
   );
 };
 
 CatButton.defaultProps = {
   onClickFunction: () => { console.error('onClickFunction is not defined');},
-  label: 'button',
-  width: 42,
+  text: 'button',
+  width: 50,
   height: 42,
 };
 

--- a/frontend/src/game/components/GameStartWrapper.tsx
+++ b/frontend/src/game/components/GameStartWrapper.tsx
@@ -1,0 +1,51 @@
+import { useContext } from 'react';
+import CatButton from '@/_components/CatButton';
+import { SocketContext } from '@/context/socket';
+import styles from '../styles/Start.module.css';
+
+const GameStartWrapper = () => {
+  const socket = useContext(SocketContext);
+  const buttonWidth = 100;
+  const buttonHeight = 80;
+
+  return (
+    <div className={styles.buttonWrapper}>
+      <div className={styles.buttonOption}>
+        <CatButton
+          onClickFunction={() => {
+            socket.emit('game-randomStart');
+          }}
+          text="rank pn"
+          width={buttonWidth}
+          height={buttonHeight}
+        />
+        <CatButton
+          onClickFunction={() => {
+            socket.emit('game-loading');
+          }}
+          text="normal pn"
+          width={buttonWidth}
+          height={buttonHeight}
+        />
+        <CatButton
+          onClickFunction={() => {
+            socket.emit('game-loading');
+          }}
+          text="rank origin"
+          width={buttonWidth}
+          height={buttonHeight}
+        />
+        <CatButton
+          onClickFunction={() => {
+            socket.emit('game-loading');
+          }}
+          text="normal origin"
+          width={buttonWidth}
+          height={buttonHeight}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default GameStartWrapper;

--- a/frontend/src/game/components/GameStartWrapper.tsx
+++ b/frontend/src/game/components/GameStartWrapper.tsx
@@ -13,7 +13,7 @@ const GameStartWrapper = () => {
       <div className={styles.buttonOption}>
         <CatButton
           onClickFunction={() => {
-            socket.emit('game-randomStart');
+            socket.emit('game-randomStart-rank-pn');
           }}
           text="rank pn"
           width={buttonWidth}
@@ -21,7 +21,7 @@ const GameStartWrapper = () => {
         />
         <CatButton
           onClickFunction={() => {
-            socket.emit('game-loading');
+            socket.emit('game-randomStart-normal-pn');
           }}
           text="normal pn"
           width={buttonWidth}
@@ -29,7 +29,7 @@ const GameStartWrapper = () => {
         />
         <CatButton
           onClickFunction={() => {
-            socket.emit('game-loading');
+            socket.emit('game-randomStart-rank-origin');
           }}
           text="rank origin"
           width={buttonWidth}
@@ -37,7 +37,7 @@ const GameStartWrapper = () => {
         />
         <CatButton
           onClickFunction={() => {
-            socket.emit('game-loading');
+            socket.emit('game-randomStart-normal-origin');
           }}
           text="normal origin"
           width={buttonWidth}

--- a/frontend/src/game/components/Start.tsx
+++ b/frontend/src/game/components/Start.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, useContext, useState } from 'react';
 import { SocketContext } from '@/context/socket';
 import { PlayerNumber } from '@/game/gameType';
-import styles from '@/game/styles/Start.module.css';
+import GameStartWrapper from './GameStartWrapper';
 
 export default function Start({ setGameStatus, setPlayerNumber, setOpponentId }
   : { setGameStatus: Dispatch<SetStateAction<number>>, setPlayerNumber: Dispatch<SetStateAction<PlayerNumber | undefined>>, setOpponentId: Dispatch<SetStateAction<string | undefined>>}) {
@@ -26,10 +26,6 @@ export default function Start({ setGameStatus, setPlayerNumber, setOpponentId }
   return (
     loading ?
       'Loading' :
-      <div className={styles.buttonWrapper} onClick={() => {
-        socket.emit('game-randomStart');
-      }} tabIndex={0}>
-        <button className={styles.startButton}>Start</button>
-      </div> 
+      <GameStartWrapper />
   );
 }

--- a/frontend/src/game/components/Start.tsx
+++ b/frontend/src/game/components/Start.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useContext, useState } from 'react';
 import { SocketContext } from '@/context/socket';
-import { PlayerNumber } from '@/game/gameType';
+import { PlayerNumber, GameStatus } from '@/game/gameType';
 import GameStartWrapper from './GameStartWrapper';
 
 export default function Start({ setGameStatus, setPlayerNumber, setOpponentId }
@@ -8,6 +8,7 @@ export default function Start({ setGameStatus, setPlayerNumber, setOpponentId }
   const socket = useContext(SocketContext);
   const [ loading, setLoading ] = useState(false);
 
+  // TODO: 추후 rank - origin, normal - origin 의 경우의 수에 따라 socket.on 을 추가해야 함
   socket.on('game-randomStart-rank-pn', ({player1Id, player2Id}: {player1Id: string, player2Id: string}) => {
     if (socket.id === player1Id) { 
       setPlayerNumber('player1');
@@ -17,7 +18,7 @@ export default function Start({ setGameStatus, setPlayerNumber, setOpponentId }
       setPlayerNumber('player2');
       setOpponentId(player1Id);
     }
-    setGameStatus(1);
+    setGameStatus(GameStatus.RankPnRun);
   });
   socket.on('game-loading', () => {
     setLoading(true);

--- a/frontend/src/game/components/Start.tsx
+++ b/frontend/src/game/components/Start.tsx
@@ -8,7 +8,7 @@ export default function Start({ setGameStatus, setPlayerNumber, setOpponentId }
   const socket = useContext(SocketContext);
   const [ loading, setLoading ] = useState(false);
 
-  socket.on('game-randomStart', ({player1Id, player2Id}: {player1Id: string, player2Id: string}) => {
+  socket.on('game-randomStart-rank-pn', ({player1Id, player2Id}: {player1Id: string, player2Id: string}) => {
     if (socket.id === player1Id) { 
       setPlayerNumber('player1');
       setOpponentId(player2Id);

--- a/frontend/src/game/components/StartWrapper.tsx
+++ b/frontend/src/game/components/StartWrapper.tsx
@@ -1,10 +1,8 @@
-import { useContext, Dispatch, SetStateAction } from 'react';
+import { useContext } from 'react';
 import CatButton from '@/_components/CatButton';
 import { SocketContext } from '@/context/socket';
 
-const GameStartWrapper = ({ setGameStatus, setPlayerNumber, setOpponentId }
-  : { setGameStatus: Dispatch<SetStateAction<number>>, setPlayerNumber: Dispatch<SetStateAction<PlayerNumber | undefined>>, setOpponentId: Dispatch<SetStateAction<string | undefined>>}
-) => {
+const GameStartWrapper = () => {
   const socket = useContext(SocketContext);
 
   <CatButton onClickFunction={() => {

--- a/frontend/src/game/components/StartWrapper.tsx
+++ b/frontend/src/game/components/StartWrapper.tsx
@@ -1,0 +1,15 @@
+import { useContext, Dispatch, SetStateAction } from 'react';
+import CatButton from '@/_components/CatButton';
+import { SocketContext } from '@/context/socket';
+
+const GameStartWrapper = ({ setGameStatus, setPlayerNumber, setOpponentId }
+  : { setGameStatus: Dispatch<SetStateAction<number>>, setPlayerNumber: Dispatch<SetStateAction<PlayerNumber | undefined>>, setOpponentId: Dispatch<SetStateAction<string | undefined>>}
+) => {
+  const socket = useContext(SocketContext);
+
+  <CatButton onClickFunction={() => {
+    socket.emit('game-randomStart-rank-pn');
+  }} text="Start" width={50} height={42} />;
+};
+
+export default GameStartWrapper;

--- a/frontend/src/game/gameType.ts
+++ b/frontend/src/game/gameType.ts
@@ -44,3 +44,13 @@ export type CanvasSize = {
   width: number;
   height: number;
 };
+
+export enum GameStatus {
+	Start,
+	RankPnRun,
+  NormalPnRun,
+  RankOriginRun,
+  NormalOriginRun,
+	End
+}
+

--- a/frontend/src/game/styles/Start.module.css
+++ b/frontend/src/game/styles/Start.module.css
@@ -1,15 +1,13 @@
-/* TODO: 이렇게 파일 분리하는게 맞는가? */
-.buttonWrapper {
-    display: flex;
-    /* 수직 배열 */
-    flex-direction: column;
-    /* 수평 정렬 */
-    justify-content: center;
-    /* 수직 정렬 */
-    align-items: center;
-    height: 100vh;
+.buttonOption {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+    margin: 10px;
 }
 
-.startButton {
-    padding: 10px 20px;
+.buttonWrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
 }

--- a/frontend/src/pages/game/index.tsx
+++ b/frontend/src/pages/game/index.tsx
@@ -1,17 +1,9 @@
 import Start from '@/game/components/Start';
 import RunWrapper from '@/game/components/RunWrapper';
 import End from '@/game/components/End';
-import { PlayerNumber, Score } from '@/game/gameType';
+import { PlayerNumber, Score, GameStatus } from '@/game/gameType';
 import { useState } from 'react';
 
-enum GameStatus {
-	Start,
-	RankPnRun,
-  NormalPnRun,
-  RankOriginRun,
-  NormalOriginRun,
-	End
-}
 
 export default function Game(): JSX.Element {
   // TODO: start game button

--- a/frontend/src/pages/game/index.tsx
+++ b/frontend/src/pages/game/index.tsx
@@ -6,7 +6,10 @@ import { useState } from 'react';
 
 enum GameStatus {
 	Start,
-	Run,
+	RankPnRun,
+  NormalPnRun,
+  RankOriginRun,
+  NormalOriginRun,
 	End
 }
 
@@ -21,7 +24,14 @@ export default function Game(): JSX.Element {
   switch (gameStatus) {
   case GameStatus.Start:
     return (<Start setGameStatus={setGameStatus} setPlayerNumber={setPlayerNumber} setOpponentId={setOpponentId} />);
-  case GameStatus.Run:
+  // TODO: 각  모드에 맞게  수정  필요
+  case GameStatus.RankPnRun:
+    return (<RunWrapper setGameStatus={setGameStatus} playerNumber={playerNumber} opponentId={opponentId} score={score} setScore={setScore}/>);
+  case GameStatus.NormalPnRun:
+    return (<RunWrapper setGameStatus={setGameStatus} playerNumber={playerNumber} opponentId={opponentId} score={score} setScore={setScore}/>);
+  case GameStatus.RankOriginRun:
+    return (<RunWrapper setGameStatus={setGameStatus} playerNumber={playerNumber} opponentId={opponentId} score={score} setScore={setScore}/>);
+  case GameStatus.NormalOriginRun:
     return (<RunWrapper setGameStatus={setGameStatus} playerNumber={playerNumber} opponentId={opponentId} score={score} setScore={setScore}/>);
   case GameStatus.End:
     return (<End setGameStatus={setGameStatus} setPlayerNumber={setPlayerNumber} />);


### PR DESCRIPTION
# SUMMARY
다양한 게임모드를 지원하기 위한 프론트 화면

# PREVIEW
<img width="479" alt="image" src="https://github.com/pong-nyan/pong-nyan/assets/62806979/ad652fcc-1da4-4c14-aa06-6a63b62e1002">

# CORE LOGIC
```ts
 switch (gameStatus) {
  case GameStatus.Start:
    return (<Start setGameStatus={setGameStatus} setPlayerNumber={setPlayerNumber} setOpponentId={setOpponentId} />);
  case GameStatus.RankPnRun:
    return (<RunWrapper setGameStatus={setGameStatus} playerNumber={playerNumber} opponentId={opponentId} score={score} setScore={setScore}/>);
  case GameStatus.NormalPnRun:
    return (<RunWrapper setGameStatus={setGameStatus} playerNumber={playerNumber} opponentId={opponentId} score={score} setScore={setScore}/>);
  case GameStatus.RankOriginRun:
    return (<RunWrapper setGameStatus={setGameStatus} playerNumber={playerNumber} opponentId={opponentId} score={score} setScore={setScore}/>);
  case GameStatus.NormalOriginRun:
    return (<RunWrapper setGameStatus={setGameStatus} playerNumber={playerNumber} opponentId={opponentId} score={score} setScore={setScore}/>);
  case GameStatus.End:
    return (<End setGameStatus={setGameStatus} setPlayerNumber={setPlayerNumber} />);
	
```

https://github.com/pong-nyan/pong-nyan/pull/124/commits/9a0922c8ed7ba1427ab3759cf5e96f4260c0f008

# BREAKING CHANGE
 게임 이벤트가 pn - origin / rank - normal 모드로 총 4가지 경우의 수로 생김 : https://github.com/pong-nyan/pong-nyan/pull/124/commits/3510b845b93f4d54c4d65a80ad380fecc8223f55

CatButton의 텍스트를 입력할 수 있게 됨 https://github.com/pong-nyan/pong-nyan/pull/124/commits/70cc5022379e48e69dd1de6bb615fb377e76b310 

# HAVE TO KNOW
 프론트상에서 공통으로 사용할 컴포넌트 폴더 분리 : https://github.com/pong-nyan/pong-nyan/pull/124/commits/70cc5022379e48e69dd1de6bb615fb377e76b310

# INFO
 알면 좋을 내용
[css grid](https://studiomeal.com/archives/533) 
 p.s. 이렇게 좋은걸 두고 노가다 했었다니...