### PR TITLE
128 safari에서 nav바속 이미지 안 보이는 이슈

### DIFF
--- a/frontend/src/chat/components/NavButtonWrapper.tsx
+++ b/frontend/src/chat/components/NavButtonWrapper.tsx
@@ -4,8 +4,8 @@ import Link from 'next/link';
 
 const HomeButton = () => {
   return (
-    <button>
-      <Link href="/" style={{ position: 'relative', width: '100%', height: '100%' }}>
+    <button style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Link href="/">
         <Image src="/assets/home-button.png" alt="home-button" fill style={{ objectFit: 'contain' }} />
       </Link>
     </button>
@@ -15,9 +15,9 @@ const HomeButton = () => {
 //TODO: mikim3에게 묻고 수정-> list와 message-channel-list의 차이점
 const ListButton = () => {
   return (
-    <button>
-      <Link href="/channel/list" style={{ position: 'relative', width: '100%', height: '100%' }}>
-        <Image src="/assets/list-button.png" alt="list-button" fill style={{ objectFit: 'contain' }} />
+    <button style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Link href="/channel/list">
+        <Image src="/assets/list-button.png" alt="list-button" fill style={{ objectFit: 'contain'}} />
       </Link>
     </button>
   );
@@ -26,8 +26,8 @@ const ListButton = () => {
 //TODO: mikim3에게 링크 묻고 수정 -> list와 message-channel-list의 차이점
 const PublicChannelListButton = () => {
   return (
-    <button>
-      <Link href="/channel/public-channel-list" style={{ position: 'relative', width: '100%', height: '100%' }}>
+    <button style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Link href="/channel/public-channel-list">
         <Image src="/assets/public-room-button.png" alt="public-room-button" fill style={{ objectFit: 'contain' }} />
       </Link>
     </button>
@@ -36,9 +36,9 @@ const PublicChannelListButton = () => {
 
 const GameButton = () => {
   return (
-    <button>
-      <Link href="/game" style={{ position: 'relative', width: '100%', height: '100%' }}>
-        <Image src="/assets/game-button.png" alt="game-button" fill style={{ objectFit: 'contain' }} />
+    <button style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Link href="/game">
+        <Image src="/assets/game-button.png" alt="game-button" fill style={{ objectFit: 'contain', zIndex: 10}} />
       </Link>
     </button>
   );

--- a/frontend/src/chat/components/NavButtonWrapper.tsx
+++ b/frontend/src/chat/components/NavButtonWrapper.tsx
@@ -38,7 +38,7 @@ const GameButton = () => {
   return (
     <button style={{ position: 'relative', width: '100%', height: '100%' }}>
       <Link href="/game">
-        <Image src="/assets/game-button.png" alt="game-button" fill style={{ objectFit: 'contain', zIndex: 10}} />
+        <Image src="/assets/game-button.png" alt="game-button" fill style={{ objectFit: 'contain' }} />
       </Link>
     </button>
   );

--- a/frontend/src/pages/channel/public-channel-list.tsx
+++ b/frontend/src/pages/channel/public-channel-list.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Channel } from '@/type/chatType;
+import { Channel } from '@/type/chatType';
 import axios from 'axios';
 import useAuth from '@/context/useAuth';
 


### PR DESCRIPTION
# SUMMARY
safari 에서 nav 바속 이미지 안 보이는 이슈 해결

# PREVIEW
<img width="537" alt="image" src="https://github.com/pong-nyan/pong-nyan/assets/62806979/c1e5c9f6-3ae6-467d-9937-f3a2e48eb5e4">

# HAVE TO KNOW
사라피에서 <Image />의 부모가 `position: relative`일 때 안 되는 버그(?)가 있음.  (럭키 인터넷익스플로어...)
see : https://stackoverflow.com/questions/68526892/nextjs-image-does-not-show-on-safari
