### PR TITLE
164 seperated chatmessage with local storage

### DIFF
--- a/backend/src/chat/channel.gateway.ts
+++ b/backend/src/chat/channel.gateway.ts
@@ -6,7 +6,6 @@ import { UseGuards } from '@nestjs/common';
 import { Gateway2faGuard } from 'src/guard/gateway2fa.guard';
 import { PnJwtPayload, PnPayloadDto } from 'src/dto/pnPayload.dto';
 import { JwtService } from '@nestjs/jwt';
-import * as cookie from 'cookie';
 import { UserService } from 'src/user.service';
 
 @WebSocketGateway({
@@ -70,12 +69,12 @@ export class ChannelGateway {
   }
 
   @SubscribeMessage('chat-message-in-channel')
-  handleMessageInChannel(@ConnectedSocket() client: Socket, @MessageBody() payload: { channelId: string, message: string }) {
+  handleMessageInChannel(@ConnectedSocket() client: Socket, @MessageBody() payloadEmit: { channelId: string, message: string }, @PnJwtPayload() payload: PnPayloadDto) {
     // 해당 채널의 모든 사용자에게 메시지 전송
-    console.log('chat-message-in-channel, payload', payload);
-    const chTest = this.channelService.getChannel(payload.channelId);
+    console.log('chat-message-in-channel, payload', payloadEmit);
+    const chTest = this.channelService.getChannel(payloadEmit.channelId);
     console.log('chat-message-in-channel, chTest', chTest);
-    this.server.to(payload.channelId).emit('chat-new-message', payload.message);
+    this.server.to(payloadEmit.channelId).emit('chat-new-message', { channelId: payloadEmit.channelId, message: payloadEmit.message, sender: payload.intraId });
   }
 
   @SubscribeMessage('chat-leave-channel')

--- a/backend/src/type/chatType.ts
+++ b/backend/src/type/chatType.ts
@@ -26,3 +26,7 @@ export type ChannelInfo = {
   maxUsers: number,
 }
 
+export type Message = {
+  content: string;
+  nickname: string;
+};

--- a/frontend/src/chat/components/ChatRoom.tsx
+++ b/frontend/src/chat/components/ChatRoom.tsx
@@ -4,9 +4,10 @@ import MessageInput from './MessageInput';
 import SendMessageButton from './SendMessageButton';
 import { SocketContext } from '@/context/socket';
 import { getMessagesFromLocalStorage, addMessageToLocalStorage } from '../utils/chatLocalStorage';
+import { Message } from '@/type/chatType';
 
 function ChatRoom({ channelId, selectedChannel, onLeaveChannel }: { channelId: string, selectedChannel: { title: string }, onLeaveChannel: () => void }) {
-  const [messages, setMessages] = useState<string[]>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
   const [inputMessage, setInputMessage] = useState('');
   const [channelUsers, setChannelUsers] = useState<string[]>([]);
   const socket = useContext(SocketContext);
@@ -24,16 +25,12 @@ function ChatRoom({ channelId, selectedChannel, onLeaveChannel }: { channelId: s
 
       const loggedInUser = JSON.parse(localStorage.getItem('user') || '{}');
       const loggedInUserId = loggedInUser.intraId;
-
       if (sender === loggedInUserId) return;
-
       addMessageToLocalStorage(receivedChannelId, message);
-
       if (channelId === receivedChannelId) {
         setMessages(prevMessages => [...prevMessages, message]);
       }
     });
-
     return () => {
       socket.off('chat-new-message');
     };
@@ -51,10 +48,14 @@ function ChatRoom({ channelId, selectedChannel, onLeaveChannel }: { channelId: s
 
   const handleSendMessage = () => {
     if (inputMessage.trim() !== '') {
-      const newMessages = [...messages, inputMessage];
-      setMessages(newMessages);
-      addMessageToLocalStorage(channelId, inputMessage);
-      socket.emit('chat-message-in-channel', { channelId, message: inputMessage, sender: 'self' }); // sender 정보 추가
+      const loggedInUser = JSON.parse(localStorage.getItem('user') || '{}');
+      const newMessage = {
+        content: inputMessage,
+        nickname: loggedInUser.nickname
+      };
+      setMessages(prevMessages => [...prevMessages, newMessage]);
+      addMessageToLocalStorage(channelId, newMessage);
+      socket.emit('chat-message-in-channel', { channelId, message: newMessage });
       setInputMessage('');
     }
   };

--- a/frontend/src/chat/components/ChatRoom.tsx
+++ b/frontend/src/chat/components/ChatRoom.tsx
@@ -20,12 +20,15 @@ function ChatRoom({ channelId, selectedChannel, onLeaveChannel }: { channelId: s
 
   useEffect(() => {
     socket.on('chat-new-message', (data) => {
-      const { message, channelId: receivedChannelId } = data;
+      const { message, channelId: receivedChannelId, sender } = data;
 
-      // 메시지를 받은 채널의 localStorage에 메시지를 추가합니다.
+      const loggedInUser = JSON.parse(localStorage.getItem('user') || '{}');
+      const loggedInUserId = loggedInUser.intraId;
+
+      if (sender === loggedInUserId) return;
+
       addMessageToLocalStorage(receivedChannelId, message);
 
-      // 현재 선택된 채널이 메시지를 받은 채널과 같다면, 상태도 업데이트합니다.
       if (channelId === receivedChannelId) {
         setMessages(prevMessages => [...prevMessages, message]);
       }
@@ -51,7 +54,7 @@ function ChatRoom({ channelId, selectedChannel, onLeaveChannel }: { channelId: s
       const newMessages = [...messages, inputMessage];
       setMessages(newMessages);
       addMessageToLocalStorage(channelId, inputMessage);
-      socket.emit('chat-message-in-channel', { channelId, message: inputMessage });
+      socket.emit('chat-message-in-channel', { channelId, message: inputMessage, sender: 'self' }); // sender 정보 추가
       setInputMessage('');
     }
   };

--- a/frontend/src/chat/components/MessageList.tsx
+++ b/frontend/src/chat/components/MessageList.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { Message } from '@/type/chatType';
 
-function MessageList({ messages }: { messages: string[] }) {
+function MessageList({ messages }: { messages: Message[] }) {
   return (
-    <div style={{ flex: 1, overflowY: 'auto' }}>
+    <div>
       {messages.map((message, index) => (
-        // TODO: 여기에서 유저 아이디를 profile 컴포넌트로 넘겨줌
-        // TODO: 띄워야 하는 요소는 이미지 유저의 아이디
-        <div key={index}>{message}</div>
+        <div key={index}>
+          {/* TODO: 여기에서 유저 아이디를 profile 컴포넌트로 넘겨줌 */}
+          <strong>{message.nickname}</strong>
+          <p>{message.content}</p>
+        </div>
       ))}
     </div>
   );

--- a/frontend/src/chat/utils/chatLocalStorage.ts
+++ b/frontend/src/chat/utils/chatLocalStorage.ts
@@ -1,4 +1,4 @@
-export function saveMessageToLocalStorage(channelId: string, message: string) {
+export function addMessageToLocalStorage(channelId: string, message: string) {
   const key = `channel-${channelId}-messages`;
   const storedMessages = localStorage.getItem(key);
   const existingMessages = storedMessages ? JSON.parse(storedMessages) : [];

--- a/frontend/src/chat/utils/chatLocalStorage.ts
+++ b/frontend/src/chat/utils/chatLocalStorage.ts
@@ -1,4 +1,6 @@
-export function addMessageToLocalStorage(channelId: string, message: string) {
+import { Message } from '@/type/chatType';
+
+export function addMessageToLocalStorage(channelId: string, message: Message) {
   const key = `channel-${channelId}-messages`;
   const storedMessages = localStorage.getItem(key);
   const existingMessages = storedMessages ? JSON.parse(storedMessages) : [];

--- a/frontend/src/chat/utils/chatLocalStorage.ts
+++ b/frontend/src/chat/utils/chatLocalStorage.ts
@@ -1,0 +1,13 @@
+export function saveMessageToLocalStorage(channelId: string, message: string) {
+  const key = `channel-${channelId}-messages`;
+  const storedMessages = localStorage.getItem(key);
+  const existingMessages = storedMessages ? JSON.parse(storedMessages) : [];
+  existingMessages.push(message);
+  localStorage.setItem(key, JSON.stringify(existingMessages));
+}
+
+export function getMessagesFromLocalStorage(channelId: string) {
+  const key = `channel-${channelId}-messages`;
+  const storedMessages = localStorage.getItem(key);
+  return storedMessages ? JSON.parse(storedMessages) : [];
+}

--- a/frontend/src/type/chatType.ts
+++ b/frontend/src/type/chatType.ts
@@ -19,3 +19,8 @@ export type ChannelInfo = {
   channelType: 'public' | 'private' | 'protected',
   maxUsers: number,
 }
+
+export type Message = {
+  content: string;
+  nickname: string;
+};


### PR DESCRIPTION
# SUMMARY
- 보낸 메시지정보를 localStorage에 저장
- 해당 정보에 user의 nickname도 포함시켰습니다.
- 본인이 보낸 메시지 본인도 받아서 두번뜨던 문제 해결했습니다.

# PREVIEW
https://github.com/pong-nyan/pong-nyan/assets/26201797/8be07ce9-ec3a-465e-955b-08e3d61e5c73

# 살짝 걱정되는것
채팅구현은 순조롭게 구현되고 있습니다.  딱히 크게 막히는거 없이 진행은 되고 있습니다. 
하지만  시간이 얼마 안 남았고 채팅이 구현해야 될게 너무 여러가지여서 걱정되네요

## 남은 일 
- 새로고침 했을때도 localStorage에 내용 
- DM구현하기
- 채팅방을 새로운 URL에서 보여주기?
- 그 외 잔 버그들이 너무 많음


