### PR TITLE
203 matching queue list 구현

### DIFF
--- a/backend/src/app.gateway.ts
+++ b/backend/src/app.gateway.ts
@@ -55,6 +55,5 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const updateUserInfo = { ...userInfo, online: false };
     console.log('>>> [AppGateway] setUserMap', updateUserInfo);
     this.userService.setUserMap(intraId, updateUserInfo);
-    this.userService.deleteIdMap(client.id);
   }
 }


### PR DESCRIPTION
# SUMMARY
- 서로 다른 큐에 대기
- 만약 새로고침하면 큐 돌아보면서 해당 소켓 있으면 지워주는 removeClient 매서드 변경
# PREVIEW
<img width="909" alt="image" src="https://github.com/pong-nyan/pong-nyan/assets/60354633/8782ecbb-3dc0-4130-ac09-9c2b5032f288">

# HAVE TO KNOW
- app gateway가 아닌 google2fa gateway에서 ipMap 지워줘야 chat, game에서 해당 로직을 사용할 수 있음
- enum으로 Run 각각의 큐를 사용하는 것
```
gameStatusIndex = gameStatus  - 1
```

<img width="322" alt="image" src="https://github.com/pong-nyan/pong-nyan/assets/60354633/cefa97fd-716e-4eeb-9255-391776276ab8">
