### PR TITLE
201 새로고침 해야만 접속 가능한 이유 고치기

### DIFF
--- a/backend/src/auth/google2fa.gateway.ts
+++ b/backend/src/auth/google2fa.gateway.ts
@@ -26,6 +26,6 @@ export class Google2faGateway {
   @SubscribeMessage('auth-set-map')
   handleAuthSetMap(@ConnectedSocket() client: Socket, @PnJwtPayload() payload: PnPayloadDto) {
     console.log('handleAuthSetMap client.id intraId', client.id, payload.intraId);
-    // this.userService.setIdMap(client.id, payload.intraId);
+    this.userService.setIdMap(client.id, payload.intraId);
   }
 }

--- a/frontend/src/auth/components/Google2FA.tsx
+++ b/frontend/src/auth/components/Google2FA.tsx
@@ -18,7 +18,7 @@ const Google2FA = () => {
           localStorage.setItem('user', JSON.stringify(res.data));
           console.log('Emitting auth-set-map');
           socket.emit('auth-set-map');
-          router.push('/');
+          location.replace('/');
         }
       })
       .catch((err) => {


### PR DESCRIPTION
# SUMMARY
pn-jwt 발급할 때 새로고침해서 소켓에도 pn-jwt가 연결되게함.

소켓에 있는 쿠키는 처음 연결될 때만 동기화됨. 소켓 연결은 pn-jwt보다 선행함. 따라서 새로고침하기전까지는 `pn-jwt`  가 없음

# REFERENCE
https://socket.io/how-to/deal-with-cookies
